### PR TITLE
fix: `std::io::Error::get_class()` for unstable `ErrorKind`s

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.83.0"
 components = [ "clippy", "rustfmt" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,16 +303,13 @@ impl JsErrorClass for std::io::Error {
       UnexpectedEof => "UnexpectedEof",
       Other => GENERIC_ERROR,
       WouldBlock => "WouldBlock",
-      kind => {
-        let kind_str = kind.to_string();
-        match kind_str.as_str() {
-          "FilesystemLoop" => "FilesystemLoop",
-          "IsADirectory" => "IsADirectory",
-          "NetworkUnreachable" => "NetworkUnreachable",
-          "NotADirectory" => "NotADirectory",
-          _ => GENERIC_ERROR,
-        }
-      }
+      kind => match format!("{kind:?}").as_str() {
+        "FilesystemLoop" => "FilesystemLoop",
+        "IsADirectory" => "IsADirectory",
+        "NetworkUnreachable" => "NetworkUnreachable",
+        "NotADirectory" => "NotADirectory",
+        _ => GENERIC_ERROR,
+      },
     };
 
     Cow::Borrowed(class)
@@ -666,5 +663,29 @@ impl JsErrorBox {
   // Non-standard errors
   pub fn not_supported() -> JsErrorBox {
     Self::new(NOT_SUPPORTED_ERROR, "The operation is not supported")
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::io;
+
+  use super::JsErrorClass;
+
+  #[test]
+  fn test_io_error_class_stable() {
+    assert_eq!(
+      io::Error::new(io::ErrorKind::NotFound, "").get_class(),
+      "NotFound",
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn test_io_error_class_unstable() {
+    assert_eq!(
+      io::Error::from_raw_os_error(libc::ELOOP).get_class(),
+      "FilesystemLoop",
+    );
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,11 +303,11 @@ impl JsErrorClass for std::io::Error {
       UnexpectedEof => "UnexpectedEof",
       Other => GENERIC_ERROR,
       WouldBlock => "WouldBlock",
+      IsADirectory => "IsADirectory",
+      NetworkUnreachable => "NetworkUnreachable",
+      NotADirectory => "NotADirectory",
       kind => match format!("{kind:?}").as_str() {
         "FilesystemLoop" => "FilesystemLoop",
-        "IsADirectory" => "IsADirectory",
-        "NetworkUnreachable" => "NetworkUnreachable",
-        "NotADirectory" => "NotADirectory",
         _ => GENERIC_ERROR,
       },
     };


### PR DESCRIPTION
We need to use the `Debug` representation of `ErrorKind` rather than its [`Display` representation](https://github.com/rust-lang/rust/blob/ae06b79dcb31c17f502f30a7848cf2bb564be1db/library/std/src/io/error.rs#L449-L494). There are alternatives (see below), but I wanted to keep the changes minimal:

- Use `Error::raw_or_error()` and match against some codes, at the risk of requiring more work to support non-Unix platforms.

- If we switch to Rust 1.83.0, `ErrorKind::{IsADirectory,NetworkUnreachable,NotADirectory}` are stable and don't require that trick anymore. `FilesystemLoop` remains unstable, however.
