### PR TITLE
use std::error::Error instead of std::any::Any

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-2019]
+        os: [macOS-latest, ubuntu-latest, windows-2022]
 
     env:
       CARGO_INCREMENTAL: 0

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -324,7 +324,7 @@ fn js_error(item: TokenStream) -> Result<TokenStream, Error> {
       ) -> ::deno_error::AdditionalProperties {
         #properties
       }
-      fn as_any(&self) -> &dyn ::std::any::Any {
+      fn get_ref(&self) -> &(dyn ::std::error::Error + Send + Sync + 'static) {
         self
       }
     }


### PR DESCRIPTION
when working with error types its much more useful to work with `Error` instead of `Any`, as both support downcasting but can't be cast between each other.